### PR TITLE
Include Matomo legacy data

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,9 +31,20 @@ We can re-purpose a lot of the code in [asu_collection_extras](https://github.co
 
 The new structure will allow a monthly download graph; although for now we will simply sum the counts for display. This also means updates simply updates for a given period and can avoid double-counting during updates.
 
-# TODO: 
+### Updating the Counts
 
-- Drush command to load Updated Google Analytics data.
+We now have a Drush command that will query the Google Analytics endpoint for item counts for either "this" or "last" month. A full load of "last" month's data took ~1.5 minutes and created records for 4,233 items.
+
+```sh
+drush --uri https://keep-dev.lib.asu.edu aia-gga last
+```
+
+We just need to run that on the first day of every month to get a final accounting of the past month.
+
+We can also cron "this" month on a regular basis to get updated current-month counts.
+
+## TODO: 
+
 - Possibly preprocess Matomo data for loading.
 - Drush command to load historic Matomo data.
 - New block for displaying the download count.

--- a/README.md
+++ b/README.md
@@ -24,3 +24,55 @@ $request->setDimensionFilter(new FilterExpression([ 'filter' => new Filter(['fie
 ```
 
 We can also adjust the DateRange to be from the day of the last run through 'yesterday' to ensure we don't double-count events.
+
+### Database Structure
+
+We can re-purpose a lot of the code in [asu_collection_extras](https://github.com/asulibraries/islandora-repo/tree/develop/web/modules/custom/asu_collection_extras); but we are using it differently, so we won't just tie into the exsiting ones.
+
+```php
+$schema = [
+    'item_analytic_counts' => [
+      'description' => 'Stores the item event counts by period.',
+      'fields' => [
+        'iid' => [
+          'description' => "The item's id this record affects.",
+          'type' => 'int',
+          'unsigned' => TRUE,
+          'not null' => TRUE,
+          'default' => 0,
+        ],
+        'type' => [
+          'description' => 'Item type. (E.g. node, taxonomy_term, or media.)',
+          'type' => 'varchar_ascii',
+          'length' => DRUPAL_EXTENSION_NAME_MAX_LENGTH,
+          'not null' => TRUE,
+          'default' => '',
+        ],
+        'event' => [
+          'description' => 'Event name we are tracking.',
+          'type' => 'varchar_ascii',
+          'length' => DRUPAL_EXTENSION_NAME_MAX_LENGTH,
+          'not null' => TRUE,
+          'default' => '',
+        ],
+        'period' => [
+          'description' => 'Period for the event count in the format "YYYY-mm".',
+          'type' => 'varchar_ascii',
+          'length' => 7,
+          'not null' => TRUE,
+          'default' => '',
+        ],
+        'count' => [
+          'description' => 'Event count for the item.',
+          'type' => 'int',
+          'not null' => TRUE,
+          'default' => 0,
+        ],
+      ],
+      'primary key' => ['iid', 'type', 'event', 'period'],
+      'indexes' => ['item' => ['iid','type']],
+    ],
+];
+```
+
+With this structure we can build a monthly download graph; although for now we will simply sum the counts for display. This also means updates simply updates for a given period and can avoid double-counting during updates.

--- a/README.md
+++ b/README.md
@@ -29,50 +29,11 @@ We can also adjust the DateRange to be from the day of the last run through 'yes
 
 We can re-purpose a lot of the code in [asu_collection_extras](https://github.com/asulibraries/islandora-repo/tree/develop/web/modules/custom/asu_collection_extras); but we are using it differently, so we won't just tie into the exsiting ones.
 
-```php
-$schema = [
-    'item_analytic_counts' => [
-      'description' => 'Stores the item event counts by period.',
-      'fields' => [
-        'iid' => [
-          'description' => "The item's id this record affects.",
-          'type' => 'int',
-          'unsigned' => TRUE,
-          'not null' => TRUE,
-          'default' => 0,
-        ],
-        'type' => [
-          'description' => 'Item type. (E.g. node, taxonomy_term, or media.)',
-          'type' => 'varchar_ascii',
-          'length' => DRUPAL_EXTENSION_NAME_MAX_LENGTH,
-          'not null' => TRUE,
-          'default' => '',
-        ],
-        'event' => [
-          'description' => 'Event name we are tracking.',
-          'type' => 'varchar_ascii',
-          'length' => DRUPAL_EXTENSION_NAME_MAX_LENGTH,
-          'not null' => TRUE,
-          'default' => '',
-        ],
-        'period' => [
-          'description' => 'Period for the event count in the format "YYYY-mm".',
-          'type' => 'varchar_ascii',
-          'length' => 7,
-          'not null' => TRUE,
-          'default' => '',
-        ],
-        'count' => [
-          'description' => 'Event count for the item.',
-          'type' => 'int',
-          'not null' => TRUE,
-          'default' => 0,
-        ],
-      ],
-      'primary key' => ['iid', 'type', 'event', 'period'],
-      'indexes' => ['item' => ['iid','type']],
-    ],
-];
-```
+The new structure will allow a monthly download graph; although for now we will simply sum the counts for display. This also means updates simply updates for a given period and can avoid double-counting during updates.
 
-With this structure we can build a monthly download graph; although for now we will simply sum the counts for display. This also means updates simply updates for a given period and can avoid double-counting during updates.
+# TODO: 
+
+- Drush command to load Updated Google Analytics data.
+- Possibly preprocess Matomo data for loading.
+- Drush command to load historic Matomo data.
+- New block for displaying the download count.

--- a/README.md
+++ b/README.md
@@ -11,3 +11,16 @@ Requires configuration (`/admin/config/system/asu-item-analytics-settings`):
 The module includes a block for displaying the download count for the current page. We are using a twig tweak call in our templates to display the block rather than using the block placement configuration.
 
 To reduce page-load time, the block uses JavaScript to call a provided JSON endpoint to get monthly totals since the beginning of 2024. We simply total those and display it. Other visualizations or endpoints could be future enhancements.
+
+## Matomo Legacy Branch
+
+This branch is exploring an alternative model, closer to the previous one. In this case, rather than pulling live data, we pull from the API on a regular basis to update a download count table. This is the old model used for Matomo. The primary rationale for this is that the Google Analytics doesn't allow us to migrate in old item count data. So, if we want to preserve existing data, we need to reuse the existing model.
+
+The [existing query](src/Controller/Controller.php#L68-L128) could be re-written to get counts by path:
+
+```php
+$request->setDimensions([new Dimension(['name' => 'pagePath'])]);
+$request->setDimensionFilter(new FilterExpression([ 'filter' => new Filter(['field_name' => 'eventName', 'in_list_filter' => new InListFilter(['values'=>['resource_engagement']])])]));
+```
+
+We can also adjust the DateRange to be from the day of the last run through 'yesterday' to ensure we don't double-count events.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ASU Item Analytics
 ==================
 
-Provides an integration with Google Analytics to display a "download" count based on a configured event name associated with the item being displayed.
+Provides a download count including data previously gathered by Matomo and new counts from Google Analytics. The Google Analytics counts are based on a configured event name associated with the item being displayed.
 
 Requires configuration (`/admin/config/system/asu-item-analytics-settings`):
 - *Credentials File Path*: key file with Google credentials allowing us to access the Analytics API. See the [Google Cloud Console](https://console.cloud.google.com/apis/dashboard) to add the Analytics API, create a Service Account, and download the credentials file to the server. (Obviously, store the file in a protected place outside of web root.) Add the service account as a viewer to the analytics account you will be querying data for.
@@ -10,41 +10,14 @@ Requires configuration (`/admin/config/system/asu-item-analytics-settings`):
 
 The module includes a block for displaying the download count for the current page. We are using a twig tweak call in our templates to display the block rather than using the block placement configuration.
 
-To reduce page-load time, the block uses JavaScript to call a provided JSON endpoint to get monthly totals since the beginning of 2024. We simply total those and display it. Other visualizations or endpoints could be future enhancements.
+## Replacing Existing Analytics
 
-## Matomo Legacy Branch
+The [asu_collection_extras](https://github.com/asulibraries/islandora-repo/tree/develop/web/modules/custom/asu_collection_extras) module had support for analytics counts but used a different structure and is now deprecated.
 
-This branch is exploring an alternative model, closer to the previous one. In this case, rather than pulling live data, we pull from the API on a regular basis to update a download count table. This is the old model used for Matomo. The primary rationale for this is that the Google Analytics doesn't allow us to migrate in old item count data. So, if we want to preserve existing data, we need to reuse the existing model.
+## Updating the Counts
 
-The [existing query](src/Controller/Controller.php#L68-L128) could be re-written to get counts by path:
-
-```php
-$request->setDimensions([new Dimension(['name' => 'pagePath'])]);
-$request->setDimensionFilter(new FilterExpression([ 'filter' => new Filter(['field_name' => 'eventName', 'in_list_filter' => new InListFilter(['values'=>['resource_engagement']])])]));
-```
-
-We can also adjust the DateRange to be from the day of the last run through 'yesterday' to ensure we don't double-count events.
-
-### Database Structure
-
-We can re-purpose a lot of the code in [asu_collection_extras](https://github.com/asulibraries/islandora-repo/tree/develop/web/modules/custom/asu_collection_extras); but we are using it differently, so we won't just tie into the exsiting ones.
-
-The new structure will allow a monthly download graph; although for now we will simply sum the counts for display. This also means updates simply updates for a given period and can avoid double-counting during updates.
-
-### Updating the Counts
-
-We now have a Drush command that will query the Google Analytics endpoint for item counts for either "this" or "last" month. A full load of "last" month's data took ~1.5 minutes and created records for 4,233 items.
+Google Analytics are gathered via a Drush command which takes a valid PHP Date Format string, including relative formats (e.g. "2024-03", "2024-03-03", "this month", or "last month"). Analytics are gathered by the month period in which to provided parameter belongs. (E.g. "2024-03-15" will gather statistics from "2024-03-01" to "2024-03-31".) Calling the script for the same period will update the existing record.
 
 ```sh
-drush --uri https://keep-dev.lib.asu.edu aia-gga last
+drush --uri https://keep-dev.lib.asu.edu aia-gga "last month"
 ```
-
-We just need to run that on the first day of every month to get a final accounting of the past month.
-
-We can also cron "this" month on a regular basis to get updated current-month counts.
-
-## TODO: 
-
-- Possibly preprocess Matomo data for loading.
-- Drush command to load historic Matomo data.
-- New block for displaying the download count.

--- a/asu_item_analytics.install
+++ b/asu_item_analytics.install
@@ -9,7 +9,7 @@
  */
 function asu_item_analytics_schema() {
   return [
-    'item_analytic_counts' => [
+    'item_analytics_counts' => [
       'description' => 'Stores the item event counts by period.',
       'fields' => [
         'iid' => [

--- a/asu_item_analytics.install
+++ b/asu_item_analytics.install
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * @file
+ */
+
+/**
+ *
+ */
+function asu_item_analytics_schema() {
+  return [
+    'item_analytic_counts' => [
+      'description' => 'Stores the item event counts by period.',
+      'fields' => [
+        'iid' => [
+          'description' => "The item's id this record affects.",
+          'type' => 'int',
+          'unsigned' => TRUE,
+          'not null' => TRUE,
+          'default' => 0,
+        ],
+        'type' => [
+          'description' => 'Item type. (E.g. node, taxonomy_term, or media.)',
+          'type' => 'varchar_ascii',
+          'length' => DRUPAL_EXTENSION_NAME_MAX_LENGTH,
+          'not null' => TRUE,
+          'default' => '',
+        ],
+        'event' => [
+          'description' => 'Event name we are tracking.',
+          'type' => 'varchar_ascii',
+          'length' => DRUPAL_EXTENSION_NAME_MAX_LENGTH,
+          'not null' => TRUE,
+          'default' => '',
+        ],
+        'period' => [
+          'description' => 'Period for the event count in the format "YYYY-mm".',
+          'type' => 'varchar_ascii',
+          'length' => 7,
+          'not null' => TRUE,
+          'default' => '',
+        ],
+        'count' => [
+          'description' => 'Event count for the item.',
+          'type' => 'int',
+          'not null' => TRUE,
+          'default' => 0,
+        ],
+      ],
+      'primary key' => ['iid', 'type', 'event', 'period'],
+      'indexes' => ['item' => ['iid', 'type']],
+    ],
+  ];
+}

--- a/asu_item_analytics.routing.yml
+++ b/asu_item_analytics.routing.yml
@@ -6,6 +6,7 @@ asu_item_analytics.monthly:
   requirements:
     _permission: 'access content'
   options:
+    _dependency_injection: true
     parameters:
       node:
         type: entity:node 

--- a/asu_item_analytics.routing.yml
+++ b/asu_item_analytics.routing.yml
@@ -6,7 +6,6 @@ asu_item_analytics.monthly:
   requirements:
     _permission: 'access content'
   options:
-    _dependency_injection: true
     parameters:
       node:
         type: entity:node 

--- a/asu_item_analytics.services.yml
+++ b/asu_item_analytics.services.yml
@@ -1,0 +1,4 @@
+services:
+  asu_item_analytics.query:
+    class: Drupal\asu_item_analytics\Service\AnalyticsQueryService
+    arguments: ['@config.factory']

--- a/asu_item_analytics.services.yml
+++ b/asu_item_analytics.services.yml
@@ -1,4 +1,10 @@
 services:
+  asu_item_analytics.ga_query:
+    class: Drupal\asu_item_analytics\Service\GoogleAnalyticsQueryService
+    arguments: ['@config.factory']
   asu_item_analytics.query:
     class: Drupal\asu_item_analytics\Service\AnalyticsQueryService
-    arguments: ['@config.factory']
+    arguments: ['@config.factory', '@database']
+  asu_item_analytics.update:
+    class: Drupal\asu_item_analytics\Service\AnalyticsUpdateService
+    arguments: ['@config.factory', '@database']

--- a/asu_item_analytics.services.yml
+++ b/asu_item_analytics.services.yml
@@ -7,4 +7,4 @@ services:
     arguments: ['@config.factory', '@database']
   asu_item_analytics.update:
     class: Drupal\asu_item_analytics\Service\AnalyticsUpdateService
-    arguments: ['@config.factory', '@database']
+    arguments: ['@config.factory', '@database', '@cache_tags.invalidator']

--- a/css/item-analytics.css
+++ b/css/item-analytics.css
@@ -1,9 +1,9 @@
 #asu-item-analytics {
-    display: none;
+  display: none;
 }
 .popover-header {
-    display: none;
+  display: none;
 }
 .popover-body {
-    background-color: #FBEAA0;
+  background-color: #fbeaa0;
 }

--- a/drush.services.yml
+++ b/drush.services.yml
@@ -1,0 +1,5 @@
+services:
+    asu_item_analytics.commands:
+        class: Drupal\asu_item_analytics\Commands\GatherAnalytics
+        tags:
+            - { name: drush.command }

--- a/js/item-analytics.js
+++ b/js/item-analytics.js
@@ -1,34 +1,8 @@
-(function() {
+(function () {
     /**
-     * We should only be seeing paths that end in a node id,
-     * e.g. 'items/1111`, 'node/1111', or perhaps 'collections/1111',
-     * but we check and skip if not.
-     * Also, use pathname to omit query strings and page fragments.
-     */
-    let matches = window.location.pathname.match(/\d+$/);
-    if (!matches) {
-        return;
-    }
-    let nid = matches[0];
-
-    fetch(`/asu-item-analytics/${nid}/monthly`).then(response => response.json()).then(data => {
-        let download_count = Object.values(data).reduce((a, b) => parseInt(a) + parseInt(b), 0);
-        // Hide if we don't have data for it.
-        if (download_count < 1) {
-            return;
-        }
-        // Display the download count
-        let block = document.getElementById("asu-item-analytics");
-        if (!block) {return;}
-        block.innerHTML = `
-<span tabindex="0" role="button" data-placement="bottom" data-toggle="popover" data-trigger="focus" title="Information" data-content="Downloads since the beginning of 2024."><i class="fas fa-info-circle"></i></span>
-Download count: ${download_count.toLocaleString()}
-`
-        block.style.display = "block";
-
-        // Activate the info popover.
-        [].slice.call(block.querySelectorAll('[data-toggle="popover"]')).map(function (el) {
-          return new bootstrap.Popover(el)
-        })
-    });
+    * Activate the Popover utility.
+    */
+    [].slice.call(document.querySelectorAll('.block-asu-item-analytics-item-block span[data-toggle="popover"]')).map(function (el) {
+        return new bootstrap.Popover(el)
+    })
 }())

--- a/src/Commands/GatherAnalytics.php
+++ b/src/Commands/GatherAnalytics.php
@@ -18,7 +18,7 @@ class GatherAnalytics extends DrushCommands {
    * Drush command to gather and populate Google Analytics data.
    *
    * @param string $user_period
-   *   The period to collect data for. Valid options are 'this' and 'last'.
+   *   Valid PHP date time format for the month to collect data for.
    *
    * @command asu_item_analytics:gatherGoogleAnalytics
    * @aliases aia-gga

--- a/src/Commands/GatherAnalytics.php
+++ b/src/Commands/GatherAnalytics.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Drupal\asu_item_analytics\Commands;
+
+use Drupal\Component\Plugin\Exception\PluginNotFoundException;
+use Drush\Commands\DrushCommands;
+use Google\ApiCore\ApiException;
+
+/**
+ * Drush commands to update our analytics tables.
+ *
+ * @package Drupal\asu_item_analytics\Commands
+ */
+class GatherAnalytics extends DrushCommands {
+
+  /**
+   * Drush command to gather and populate Google Analytics data.
+   *
+   * @param string $which_month
+   *   The period to collect data for. Valid options are 'this' and 'last'.
+   *
+   * @command asu_item_analytics:gatherGoogleAnalytics
+   * @aliases aia-gga
+   * @usage asu_item_analytics:gatherGoogleAnalytics [this|last] --uri <site url>
+   */
+  public function gatherGoogleAnalytics($which_month) {
+
+    if (!in_array($which_month, ['this', 'last'])) {
+      $message = "Month value of '$which_month' is invalid. Please use either 'this' or 'last'.";
+      \Drupal::logger('asu_item_analytics')->error($message);
+      $this->io()->error($message);
+      return;
+    }
+    // Start and end are for the Google Query.
+    $start = date("Y-n-j", strtotime("first day of $which_month month"));
+    $end = date("Y-n-j", strtotime("last day of $which_month month"));
+    // Period is for the update service.
+    $period = date("Y-m", strtotime("$which_month month"));
+
+    try {
+      // Grab the data from Google Analytics.
+      $gaq = \Drupal::service('asu_item_analytics.ga_query');
+      $period_data = $gaq->allInDateRange($start, $end);
+
+      // Google Analytics gives us the path, which can be an alias.
+      // Currently, everything *should* have an alias (e.g. /items/{nid}).
+      // The alias repo service will help us find the right entity path.
+      $alias_repo = \Drupal::service('path_alias.repository');
+      $au = \Drupal::service('asu_item_analytics.update');
+      foreach ($this->io()->progressIterate($period_data) as $path => $count) {
+        $alias = $alias_repo->lookupByAlias($path, 'en');
+
+        // If the path *isn't* an alias, a hypothetical future usecase,
+        // such as for individual media (e.g. /media/{mid}) we populate
+        // the alias path with our actual path to keep the code simpler.
+        if (is_null($alias)) {
+          $alias = ['path' => $path];
+        }
+
+        // We have a special case where taxonomy term URLs don't follow the
+        // /{entity type}/{id} pattern. They swap the underscore with a slash,
+        // so we need to account for that in our match and later when loading
+        // the entity.
+        $m = [];
+        preg_match('|\/([a-z_\/]+)\/(\d+)|', $alias['path'], $m);
+
+        try {
+          // See note, above the preg_match call,
+          // about the taxonomy term special case.
+          $entity = \Drupal::entityTypeManager()->getStorage(str_replace('/', '_', $m[1]))->load($m[2]);
+
+          // Load it up.
+          $au->entityPeriodEventCount($entity, $gaq->getEventCode(), $period, intval($count));
+        }
+        catch (PluginNotFoundException $e) {
+          $message = "Could not load entity for '{$path}' to store count '{$count}': {$e->getMessage()}";
+          \Drupal::logger('asu_item_analytics')->warning($message);
+          $this->io()->warning($message);
+        }
+      }
+    }
+    catch (ApiException $gae) {
+      $message = "Could not get Google Analytics data for date range '$start' to '$end': {$gae->getMessage()}";
+      \Drupal::logger('asu_item_analytics')->error($message);
+      $this->io()->error($message);
+    }
+  }
+
+}

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -20,7 +20,6 @@ class Controller extends ControllerBase {
    *   The JSON response.
    */
   public function monthly($node) {
-    $path = $node->toUrl()->toString();
     $aq = \Drupal::service('asu_item_analytics.ga_query');
     $data = $aq->nodeMonthly($node);
     return new JsonResponse($data);

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -2,17 +2,8 @@
 
 namespace Drupal\asu_item_analytics\Controller;
 
-use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\asu_item_analytics\Service\AnalyticsQueryService;
 use Drupal\Core\Controller\ControllerBase;
-use Google\Analytics\Data\V1beta\Client\BetaAnalyticsDataClient;
-use Google\Analytics\Data\V1beta\DateRange;
-use Google\Analytics\Data\V1beta\Dimension;
-use Google\Analytics\Data\V1beta\Filter;
-use Google\Analytics\Data\V1beta\Filter\InListFilter;
-use Google\Analytics\Data\V1beta\FilterExpression;
-use Google\Analytics\Data\V1beta\FilterExpressionList;
-use Google\Analytics\Data\V1beta\Metric;
-use Google\Analytics\Data\V1beta\RunReportRequest;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
@@ -22,20 +13,20 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 class Controller extends ControllerBase {
 
   /**
-   * The configuration service.
+   * The analytics query service.
    *
-   * @var \Drupal\Core\Config\Config
+   * @var \Drupal\asu_item_analytics\Service\AnalyticsQueryService
    */
-  protected $config;
+  protected $analyticsQueryService;
 
   /**
-   * Constructs a new Controller object.
+   * Constructs a new AnalyticsController object.
    *
-   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
-   *   The configuration factory.
+   * @param \Drupal\asu_item_analytics\Service\AnalyticsQueryService $analytics_query_service
+   *   The analytics query service.
    */
-  public function __construct(ConfigFactoryInterface $config_factory) {
-    $this->config = $config_factory->get('asu_item_analytics.settings');
+  public function __construct(AnalyticsQueryService $analytics_query_service) {
+    $this->analyticsQueryService = $analytics_query_service;
   }
 
   /**
@@ -43,7 +34,7 @@ class Controller extends ControllerBase {
    */
   public static function create(ContainerInterface $container) {
     return new static(
-      $container->get('config.factory')
+      $container->get('asu_item_analytics.query')
     );
   }
 
@@ -57,81 +48,9 @@ class Controller extends ControllerBase {
    *   The JSON response.
    */
   public function monthly($node) {
-
     $path = $node->toUrl()->toString();
-
-    $credentialsPath = $this->config->get('credentials_path');
-    $client = new BetaAnalyticsDataClient(['credentials' => $credentialsPath]);
-    $propertyId = $this->config->get('property_id');
-    $eventName = $this->config->get('event_name');
-
-    $request = (new RunReportRequest())
-      ->setProperty('properties/' . $propertyId)
-      ->setDateRanges(
-        [
-          new DateRange(
-            [
-              // We started collecting data for the event in question in 2024.
-              'start_date' => '2024-01-01',
-              'end_date' => 'today',
-            ]
-          ),
-        ]
-    )
-      ->setDimensions(
-        [new Dimension(
-            [
-              'name' => 'yearMonth',
-            ]
-          ),
-        ]
-    )
-      ->setDimensionFilter(
-        new FilterExpression(
-            [
-              'and_group' => new FilterExpressionList(
-                [
-                  'expressions' => [
-                    new FilterExpression(
-                    [
-                      'filter' => new Filter(
-                        [
-                          'field_name' => 'eventName',
-                          'in_list_filter' => new InListFilter(['values' => [$eventName]]),
-                        ]
-                      ),
-                    ]
-                    ),
-                    new FilterExpression(
-                        [
-                          'filter' => new Filter(
-                            [
-                              'field_name' => 'pagePath',
-                              'in_list_filter' => new InListFilter(['values' => [$path]]),
-                            ]
-                          ),
-                        ]
-                    ),
-                  ],
-                ]
-              ),
-            ]
-        )
-    )
-      ->setMetrics(
-        [new Metric(
-            [
-              'name' => 'eventCount',
-            ]
-          ),
-        ]
-    );
-    $response = $client->runReport($request);
-
-    $data = [];
-    foreach ($response->getRows() as $row) {
-      $data[$row->getDimensionValues()[0]->getValue()] = $row->getMetricValues()[0]->getValue();
-    }
+    $aq = \Drupal::service('asu_item_analytics.query');
+    $data = $aq->nodeMonthly($node);
     return new JsonResponse($data);
   }
 

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -3,7 +3,6 @@
 namespace Drupal\asu_item_analytics\Controller;
 
 use Drupal\Core\Controller\ControllerBase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
 
 /**

--- a/src/Controller/Controller.php
+++ b/src/Controller/Controller.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\asu_item_analytics\Controller;
 
-use Drupal\asu_item_analytics\Service\AnalyticsQueryService;
 use Drupal\Core\Controller\ControllerBase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -11,32 +10,6 @@ use Symfony\Component\HttpFoundation\JsonResponse;
  * Provides a controller for ASU Item Analytics module.
  */
 class Controller extends ControllerBase {
-
-  /**
-   * The analytics query service.
-   *
-   * @var \Drupal\asu_item_analytics\Service\AnalyticsQueryService
-   */
-  protected $analyticsQueryService;
-
-  /**
-   * Constructs a new AnalyticsController object.
-   *
-   * @param \Drupal\asu_item_analytics\Service\AnalyticsQueryService $analytics_query_service
-   *   The analytics query service.
-   */
-  public function __construct(AnalyticsQueryService $analytics_query_service) {
-    $this->analyticsQueryService = $analytics_query_service;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public static function create(ContainerInterface $container) {
-    return new static(
-      $container->get('asu_item_analytics.query')
-    );
-  }
 
   /**
    * Returns analytics data in JSON format.
@@ -49,7 +22,7 @@ class Controller extends ControllerBase {
    */
   public function monthly($node) {
     $path = $node->toUrl()->toString();
-    $aq = \Drupal::service('asu_item_analytics.query');
+    $aq = \Drupal::service('asu_item_analytics.ga_query');
     $data = $aq->nodeMonthly($node);
     return new JsonResponse($data);
   }

--- a/src/Plugin/Block/ItemBlock.php
+++ b/src/Plugin/Block/ItemBlock.php
@@ -2,7 +2,11 @@
 
 namespace Drupal\asu_item_analytics\Plugin\Block;
 
+use Drupal\asu_item_analytics\Service\AnalyticsQueryService;
 use Drupal\Core\Block\BlockBase;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Provides a 'Item' block.
@@ -13,22 +17,106 @@ use Drupal\Core\Block\BlockBase;
  *   category = @Translation("Custom")
  * )
  */
-class ItemBlock extends BlockBase {
+class ItemBlock extends BlockBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The route match.
+   *
+   * @var \Drupal\Core\Routing\RouteMatchInterface
+   */
+  protected $routeMatch;
+
+  protected $analyticsQueryService;
+
+  /**
+   * Constructs a Drupalist object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Routing\RouteMatchInterface $route_match
+   *   The route match.
+   * @param \Drupal\asu_item_analytics\Service\AnalyticsQueryService $analyticsQueryService
+   *   The query service.
+   */
+  public function __construct(
+    array $configuration,
+    $plugin_id,
+    $plugin_definition,
+    RouteMatchInterface $route_match,
+    AnalyticsQueryService $analyticsQueryService,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->routeMatch = $route_match;
+    $this->analyticsQueryService = $analyticsQueryService;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('current_route_match'),
+      $container->get('asu_item_analytics.query')
+    );
+  }
 
   /**
    * {@inheritdoc}
    */
   public function build() {
-    // You can add any content you want to display in the block here.
-    $content = [
-      '#type' => 'container',
-      '#attributes' => ['id' => 'asu-item-analytics'],
-    ];
 
-    // Attach the library to the block.
-    $content['#attached']['library'][] = 'asu_item_analytics/item_block';
+    $entity = NULL;
+    foreach (["node", "media", "taxonomy_term"] as $type) {
+      if ($param = $this->routeMatch->getParameter($type)) {
+        $entity = (is_string($param)) ? \Drupal::entityTypeManager()->getStorage($type)->load($param) : $param;
+        break;
+      }
+    }
+    // No supported entity in the context definition.
+    if (is_null($entity)) {
+      return [];
+    }
 
-    return $content;
+    $count = array_sum($this->analyticsQueryService->entityMonthly($entity) ?? []);
+    if ($count > 0) {
+      return [
+      // '#type' => 'container',
+      //        '#attributes' => ['class' => 'asu-item-analytics'],
+        'popover' => [
+          '#type' => 'html_tag',
+          '#tag' => 'span',
+          '#attributes' => [
+            'tabindex' => '0',
+            'role' => 'button',
+            'data-placement' => 'bottom',
+            'data-toggle' => 'popover',
+            'data-trigger' => 'focus',
+            'title' => 'Information',
+            'data-content' => 'Downloads since the beginning of XXXX.',
+          ],
+          'icon' => [
+            '#type' => 'html_tag',
+            '#tag' => 'i',
+            '#attributes' => ['class' => 'fas fa-info-circle'],
+          ],
+        ],
+        'count' => [
+          '#type' => 'plain_text',
+          '#plain_text' => 'Download count: ' . number_format($count),
+        ],
+        // Attach the library to the block.
+        '#attached' => ['library' => ['asu_item_analytics/item_block' => 'asu_item_analytics/item_block']],
+      ];
+    }
+    // No data found. Return nothing.
+    return [];
   }
 
 }

--- a/src/Plugin/Block/ItemBlock.php
+++ b/src/Plugin/Block/ItemBlock.php
@@ -111,6 +111,7 @@ class ItemBlock extends BlockBase implements ContainerFactoryPluginInterface {
         ],
         // Attach the library to the block.
         '#attached' => ['library' => ['asu_item_analytics/item_block' => 'asu_item_analytics/item_block']],
+        '#cache' => ['contexts' => ['url.path']],
       ];
     }
     // No data found. Return nothing.

--- a/src/Plugin/Block/ItemBlock.php
+++ b/src/Plugin/Block/ItemBlock.php
@@ -87,8 +87,6 @@ class ItemBlock extends BlockBase implements ContainerFactoryPluginInterface {
     $count = array_sum($this->analyticsQueryService->entityMonthly($entity) ?? []);
     if ($count > 0) {
       return [
-      // '#type' => 'container',
-      //        '#attributes' => ['class' => 'asu-item-analytics'],
         'popover' => [
           '#type' => 'html_tag',
           '#tag' => 'span',
@@ -99,7 +97,7 @@ class ItemBlock extends BlockBase implements ContainerFactoryPluginInterface {
             'data-toggle' => 'popover',
             'data-trigger' => 'focus',
             'title' => 'Information',
-            'data-content' => 'Downloads since the beginning of XXXX.',
+            'data-content' => 'The repository began collecting download statistics in 2021.',
           ],
           'icon' => [
             '#type' => 'html_tag',

--- a/src/Service/AnalyticsQueryService.php
+++ b/src/Service/AnalyticsQueryService.php
@@ -77,7 +77,7 @@ class AnalyticsQueryService {
     }
 
     // Query.
-    $query = $this->connection->select('item_analytic_counts', 'iac')
+    $query = $this->connection->select('item_analytics_counts', 'iac')
       ->fields('iac', ['period'])
       ->condition('iac.iid', $entity->id())
       ->condition('iac.type', $entity->getEntityTypeId())

--- a/src/Service/AnalyticsQueryService.php
+++ b/src/Service/AnalyticsQueryService.php
@@ -146,7 +146,7 @@ class AnalyticsQueryService {
    *   The end date in 'YYYY-mm-dd' format or 'yesterday' or 'today'.
    *
    * @return array
-   *   Array of event counts keyed by month (YYYY-mm).
+   *   Array of event counts keyed by path (e.g. '/item/{nid}').
    */
   public function allInDateRange($start_date = '2024-01-01', $end_date = 'yesterday') {
 

--- a/src/Service/AnalyticsQueryService.php
+++ b/src/Service/AnalyticsQueryService.php
@@ -114,7 +114,6 @@ class AnalyticsQueryService {
    *   If the date is invalid.
    */
   private function validateDate($date) {
-    $m = [];
     if (!preg_match('/^\d{4}-(\d{2})$/', $date, $matches) || $matches[1] > 12 || $matches[1] < 1) {
       throw new \Exception("Invalid period '$date'. Period must match the pattern 'YYYY-mm', e.g. '2024-01', with a month value between 1 and 12.");
     }

--- a/src/Service/AnalyticsQueryService.php
+++ b/src/Service/AnalyticsQueryService.php
@@ -50,34 +50,76 @@ class AnalyticsQueryService {
   }
 
   /**
-   * Returns resource_engagement for nodes by month.
+   * Returns event counts for events for an entity by month.
    *
    * @param \Drupal\Core\Entity\EntityInterface $entity
    *   The entity to gather analytics on.
-   * @param array $event
-   *   Events used for reporting. Leave empty for all events.
+   * @param array $events
+   *   Events used for reporting. Leave empty for all events (default).
    * @param string $start_date
-   *   The start date in 'YYYY-mm-dd' format or 'yesterday' or 'today'.
+   *   The start date in 'YYYY-mm' format.
    * @param string $end_date
-   *   The end date in 'YYYY-mm-dd' format or 'yesterday' or 'today'.
+   *   The end date in 'YYYY-mm' format.
    *
    * @return array
    *   Array of event counts keyed by month (YYYY-mm).
+   *
+   * @throws Exception
+   *   If a function parameter is invalid.
    */
-  public function entityMonthly($entity, $event = [], $start_date = '', $end_date = '') {
-    // @todo query the item_analytic_counts table.
-    // Validation
+  public function entityMonthly($entity, $events = [], $start_date = '', $end_date = '') {
+    // Validation.
     if (!$entity instanceof EntityInterface) {
       throw new \Exception("Received a " . gettype($entity) . " instead of an entity.");
     }
+    if (!is_array($events)) {
+      throw new \Exception("Events parameter must be an array.");
+    }
+
+    // Query.
     $query = $this->connection->select('item_analytic_counts', 'iac')
-      ->fields('iac', ['period', 'count'])
+      ->fields('iac', ['period'])
       ->condition('iac.iid', $entity->id())
-      ->condition('iac.type', $entity->getEntityTypeId());
-    // @todo Add event condition if provided a non-empty event array.
-    // @todo Add start and end date if valid values provided.
-    $data = $query->execute()->fetchAllKeyed();
-    return $data;
+      ->condition('iac.type', $entity->getEntityTypeId())
+      ->groupBy('iac.period');
+    $query->addExpression('sum(iac.count)', 'count');
+
+    // Add event condition if provided a non-empty event array.
+    if (!empty($events)) {
+      $query->condition('iac.event', $events, 'IN');
+    }
+
+    // Add start and end date if valid values provided.
+    if (!empty($start_date) && $this->validateDate($start_date)) {
+      $query->condition('iac.period', $start_date, '>=');
+    }
+    if (!empty($end_date) && $this->validateDate($end_date)) {
+      $query->condition('iac.period', $end_date, '<=');
+    }
+
+    // Make it so.
+    return $query->execute()->fetchAllKeyed();
+  }
+
+  /**
+   * Ensures date string matches 'YYYY-mm'.
+   *
+   * @param string $date
+   *   The date value to validate.
+   *
+   * @return bool
+   *   True if it validates
+   *
+   * @throws Exception
+   *   If the date is invalid.
+   */
+  private function validateDate($date) {
+    $m = [];
+    if (!preg_match('/^\d{4}-(\d{2})$/', $date, $matches) || $matches[1] > 12 || $matches[1] < 1) {
+      throw new \Exception("Invalid period '$date'. Period must match the pattern 'YYYY-mm', e.g. '2024-01', with a month value between 1 and 12.");
+    }
+    return TRUE;
+
   }
 
 }

--- a/src/Service/AnalyticsQueryService.php
+++ b/src/Service/AnalyticsQueryService.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Drupal\asu_item_analytics\Service;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Google\Analytics\Data\V1beta\Client\BetaAnalyticsDataClient;
+use Google\Analytics\Data\V1beta\DateRange;
+use Google\Analytics\Data\V1beta\Dimension;
+use Google\Analytics\Data\V1beta\Filter;
+use Google\Analytics\Data\V1beta\Filter\InListFilter;
+use Google\Analytics\Data\V1beta\FilterExpression;
+use Google\Analytics\Data\V1beta\FilterExpressionList;
+use Google\Analytics\Data\V1beta\Metric;
+use Google\Analytics\Data\V1beta\RunReportRequest;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides an analytics query service.
+ */
+class AnalyticsQueryService {
+
+  /**
+   * The configuration service.
+   *
+   * @var \Drupal\Core\Config\Config
+   */
+  protected $config;
+
+  /**
+   * Constructs a new Controller object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The configuration factory.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->config = $config_factory->get('asu_item_analytics.settings');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * Returns resource_engagement for nodes by month.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node to gather analytics on.
+   * @param string $start_date
+   *   The start date in 'YYYY-mm-dd' format or 'yesterday' or 'today'.
+   * @param string $end_date
+   *   The end date in 'YYYY-mm-dd' format or 'yesterday' or 'today'.
+   *
+   * @return array
+   *   Array of event counts keyed by month (YYYY-mm).
+   */
+  public function nodeMonthly($node, $start_date = '2024-01-01', $end_date = 'yesterday') {
+
+    $path = $node->toUrl()->toString();
+
+    $credentialsPath = $this->config->get('credentials_path');
+    $client = new BetaAnalyticsDataClient(['credentials' => $credentialsPath]);
+    $propertyId = $this->config->get('property_id');
+    $eventName = $this->config->get('event_name');
+
+    $request = (new RunReportRequest())
+      ->setProperty('properties/' . $propertyId)
+      ->setDateRanges(
+        [
+          new DateRange(
+            [
+              // We started collecting data for the event in question in 2024.
+              'start_date' => $start_date,
+              'end_date' => $end_date,
+            ]
+          ),
+        ]
+    )
+      ->setDimensions(
+        [new Dimension(
+            [
+              'name' => 'yearMonth',
+            ]
+          ),
+        ]
+    )
+      ->setDimensionFilter(
+        new FilterExpression(
+            [
+              'and_group' => new FilterExpressionList(
+                [
+                  'expressions' => [
+                    new FilterExpression(
+                    [
+                      'filter' => new Filter(
+                        [
+                          'field_name' => 'eventName',
+                          'in_list_filter' => new InListFilter(['values' => [$eventName]]),
+                        ]
+                      ),
+                    ]
+                    ),
+                    new FilterExpression(
+                        [
+                          'filter' => new Filter(
+                            [
+                              'field_name' => 'pagePath',
+                              'in_list_filter' => new InListFilter(['values' => [$path]]),
+                            ]
+                          ),
+                        ]
+                    ),
+                  ],
+                ]
+              ),
+            ]
+        )
+    )
+      ->setMetrics(
+        [new Metric(
+            [
+              'name' => 'eventCount',
+            ]
+          ),
+        ]
+    );
+    $response = $client->runReport($request);
+
+    $data = [];
+    foreach ($response->getRows() as $row) {
+      $data[$row->getDimensionValues()[0]->getValue()] = $row->getMetricValues()[0]->getValue();
+    }
+    return $data;
+  }
+
+}

--- a/src/Service/AnalyticsUpdateService.php
+++ b/src/Service/AnalyticsUpdateService.php
@@ -74,7 +74,7 @@ class AnalyticsUpdateService {
       throw new \Exception("Invalid period '$period'. Period must match the pattern 'YYYY-mm', e.g. '2024-01', with a month value between 1 and 12.");
     }
     if (!is_int($count) || $count < 0) {
-      throw new \Exception("Count must be an integer with the value zero or greater.");
+      throw new \Exception("Count ($count) must be an integer with the value zero or greater.");
     }
 
     // Update the table row.

--- a/src/Service/AnalyticsUpdateService.php
+++ b/src/Service/AnalyticsUpdateService.php
@@ -69,7 +69,6 @@ class AnalyticsUpdateService {
     if (empty($event)) {
       throw new \Exception("Event must not be empty!");
     }
-    $m = [];
     if (!preg_match('/^\d{4}-(\d{2})$/', $period, $matches) || $matches[1] > 12 || $matches[1] < 1) {
       throw new \Exception("Invalid period '$period'. Period must match the pattern 'YYYY-mm', e.g. '2024-01', with a month value between 1 and 12.");
     }

--- a/src/Service/AnalyticsUpdateService.php
+++ b/src/Service/AnalyticsUpdateService.php
@@ -88,7 +88,7 @@ class AnalyticsUpdateService {
       throw new \Exception("Count ($count) must be an integer with the value zero or greater.");
     }
 
-    $existing_count = $this->connection->select('item_analytic_counts', 'iac')
+    $existing_count = $this->connection->select('item_analytics_counts', 'iac')
       ->fields('iac', ['count'])
       ->condition('iac.type', $entity->getEntityTypeId())
       ->condition('iac.iid', $entity->id())
@@ -98,7 +98,7 @@ class AnalyticsUpdateService {
     if ($count > $existing_count) {
 
       // Update the table row.
-      $this->connection->merge('item_analytic_counts')
+      $this->connection->merge('item_analytics_counts')
         ->key(['iid' => $entity->id(), 'type' => $entity->getEntityTypeId(), 'event' => $event, 'period' => $period])
         ->fields(['count' => $count])
         ->execute();

--- a/src/Service/GoogleAnalyticsQueryService.php
+++ b/src/Service/GoogleAnalyticsQueryService.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace Drupal\asu_item_analytics\Service;
+
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Google\Analytics\Data\V1beta\Client\BetaAnalyticsDataClient;
+use Google\Analytics\Data\V1beta\DateRange;
+use Google\Analytics\Data\V1beta\Dimension;
+use Google\Analytics\Data\V1beta\Filter;
+use Google\Analytics\Data\V1beta\Filter\InListFilter;
+use Google\Analytics\Data\V1beta\FilterExpression;
+use Google\Analytics\Data\V1beta\FilterExpressionList;
+use Google\Analytics\Data\V1beta\Metric;
+use Google\Analytics\Data\V1beta\RunReportRequest;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Provides an analytics query service.
+ */
+class GoogleAnalyticsQueryService {
+
+  /**
+   * The configuration service.
+   *
+   * @var \Drupal\Core\Config\Config
+   */
+  protected $config;
+
+  /**
+   * Constructs a new Controller object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The configuration factory.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory) {
+    $this->config = $config_factory->get('asu_item_analytics.settings');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * Returns resource_engagement for nodes by month.
+   *
+   * @param \Drupal\node\NodeInterface $node
+   *   The node to gather analytics on.
+   * @param string $start_date
+   *   The start date in 'YYYY-mm-dd' format or 'yesterday' or 'today'.
+   * @param string $end_date
+   *   The end date in 'YYYY-mm-dd' format or 'yesterday' or 'today'.
+   *
+   * @return array
+   *   Array of event counts keyed by month (YYYY-mm).
+   */
+  public function nodeMonthly($node, $start_date = '2024-01-01', $end_date = 'yesterday') {
+
+    $path = $node->toUrl()->toString();
+
+    $credentialsPath = $this->config->get('credentials_path');
+    $client = new BetaAnalyticsDataClient(['credentials' => $credentialsPath]);
+    $propertyId = $this->config->get('property_id');
+    $eventName = $this->config->get('event_name');
+
+    $request = (new RunReportRequest())
+      ->setProperty('properties/' . $propertyId)
+      ->setDateRanges(
+        [
+          new DateRange(
+            [
+              // We started collecting data for the event in question in 2024.
+              'start_date' => $start_date,
+              'end_date' => $end_date,
+            ]
+          ),
+        ]
+    )
+      ->setDimensions(
+        [new Dimension(
+            [
+              'name' => 'yearMonth',
+            ]
+          ),
+        ]
+    )
+      ->setDimensionFilter(
+        new FilterExpression(
+            [
+              'and_group' => new FilterExpressionList(
+                [
+                  'expressions' => [
+                    new FilterExpression(
+                    [
+                      'filter' => new Filter(
+                        [
+                          'field_name' => 'eventName',
+                          'in_list_filter' => new InListFilter(['values' => [$eventName]]),
+                        ]
+                      ),
+                    ]
+                    ),
+                    new FilterExpression(
+                        [
+                          'filter' => new Filter(
+                            [
+                              'field_name' => 'pagePath',
+                              'in_list_filter' => new InListFilter(['values' => [$path]]),
+                            ]
+                          ),
+                        ]
+                    ),
+                  ],
+                ]
+              ),
+            ]
+        )
+    )
+      ->setMetrics(
+        [new Metric(
+            [
+              'name' => 'eventCount',
+            ]
+          ),
+        ]
+    );
+    $response = $client->runReport($request);
+
+    $data = [];
+    foreach ($response->getRows() as $row) {
+      $data[$row->getDimensionValues()[0]->getValue()] = $row->getMetricValues()[0]->getValue();
+    }
+    return $data;
+  }
+
+  /**
+   * Returns resource_engagement for all pages in a given date range.
+   *
+   * @param string $start_date
+   *   The start date in 'YYYY-mm-dd' format or 'yesterday' or 'today'.
+   * @param string $end_date
+   *   The end date in 'YYYY-mm-dd' format or 'yesterday' or 'today'.
+   *
+   * @return array
+   *   Array of event counts keyed by path (e.g. '/item/{nid}').
+   */
+  public function allInDateRange($start_date = '2024-01-01', $end_date = 'yesterday') {
+
+    $credentialsPath = $this->config->get('credentials_path');
+    $client = new BetaAnalyticsDataClient(['credentials' => $credentialsPath]);
+    $propertyId = $this->config->get('property_id');
+    $eventName = $this->config->get('event_name');
+
+    $request = (new RunReportRequest())
+      ->setProperty('properties/' . $propertyId)
+      ->setDateRanges(
+        [
+          new DateRange(
+            [
+              // We started collecting data for the event in question in 2024.
+              'start_date' => $start_date,
+              'end_date' => $end_date,
+            ]
+          ),
+        ]
+    )
+      ->setDimensions(
+        [new Dimension(
+            [
+              'name' => 'pagePath',
+            ]
+          ),
+        ]
+    )
+      ->setDimensionFilter(
+        new FilterExpression(
+            [
+              'filter' => new Filter(
+                [
+                  'field_name' => 'eventName',
+                  'in_list_filter' => new InListFilter(['values' => [$eventName]]),
+                ]
+              ),
+            ]
+        )
+    )
+      ->setMetrics(
+        [new Metric(
+            [
+              'name' => 'eventCount',
+            ]
+          ),
+        ]
+    );
+    $response = $client->runReport($request);
+
+    $data = [];
+    foreach ($response->getRows() as $row) {
+      $data[$row->getDimensionValues()[0]->getValue()] = $row->getMetricValues()[0]->getValue();
+    }
+    return $data;
+  }
+
+}

--- a/src/Service/GoogleAnalyticsQueryService.php
+++ b/src/Service/GoogleAnalyticsQueryService.php
@@ -46,6 +46,15 @@ class GoogleAnalyticsQueryService {
   }
 
   /**
+   * Get configured event code.
+   *
+   * @return string
+   *   The configured event code.
+   */
+  public function getEventCode() {
+    return $this->config->get('event_name');
+  }
+  /**
    * Returns resource_engagement for nodes by month.
    *
    * @param \Drupal\node\NodeInterface $node

--- a/src/Service/GoogleAnalyticsQueryService.php
+++ b/src/Service/GoogleAnalyticsQueryService.php
@@ -54,6 +54,7 @@ class GoogleAnalyticsQueryService {
   public function getEventCode() {
     return $this->config->get('event_name');
   }
+
   /**
    * Returns resource_engagement for nodes by month.
    *


### PR DESCRIPTION
Shifts analytics data into the database:

1. Google Analytics now aggregates via Drush command.
2. Legacy Matomo data can be imported to provide historical data.
3. Block now pulls counts from the database instead of using JavaScript to update the block after loading.